### PR TITLE
Update mods.toml

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -60,12 +60,12 @@ A mod that adds Psimetal weapons of the extended types from Epic Fight Mod
     modId="psi"
     mandatory=true
     versionRange="[1.16-91,)"
-    ordering="NONE"
+    ordering="BEFORE"
     side="BOTH"
 
 [[dependencies.epicpsi]]
     modId="epicfight"
     mandatory=true
     versionRange="[1.0,)"
-    ordering="NONE"
+    ordering="BEFORE"
     side="BOTH"


### PR DESCRIPTION
改成这样应该能解决启动崩溃问题，我在开发史诗战斗的附属的时候也遇到过这种情况
产生原因：
附属由于某种原因（随机？）比前置先加载，找不到父类，然后寄